### PR TITLE
Fix useExplorer to use store and return string

### DIFF
--- a/composables/useBlockExplorer.ts
+++ b/composables/useBlockExplorer.ts
@@ -2,12 +2,16 @@ import { useNetwork } from "use-wagmi";
 import { Hash } from "viem";
 
 export const useBlockExplorer = (type: string, hash: Hash) => {
-  try {
-    return new URL(
-      `${type}/${hash}`,
-      useNetwork()?.chain?.value?.blockExplorers?.default?.url
-    );
-  } catch (error) {
-    console.log(error);
+  const network = useNetworkStore().getNetwork();
+  const { chains } = useNetwork();
+
+  const currentNetwork = computed(() => {
+    return chains.value.find((chain) => chain.id === network.value.rpc.chainId);
+  });
+
+  const explorerUrl = currentNetwork?.value?.blockExplorers?.default?.url;
+
+  if (explorerUrl) {
+    return new URL(`${type}/${hash}`, explorerUrl).toString();
   }
 };


### PR DESCRIPTION
I used the store to generate the URL, and now it returns a string because it's the type that "href" expects.
Maybe we can store wagmi data of network on the network object of the store, because it has extra data that we might use (explorers for example)