### PR TITLE
WEB3 693 MSimpleTable search and improved slots

### DIFF
--- a/components/design-system/MSimpleTable.vue
+++ b/components/design-system/MSimpleTable.vue
@@ -1,76 +1,93 @@
 <template>
-  <div class="overflow-x-auto">
-    <table class="text-left w-full">
-      <colgroup>
-        <template v-for="field in displayedFields" :key="field.key">
-          <slot :name="`col(${field.key})`">
-            <col />
-          </slot>
-        </template>
-      </colgroup>
-      <thead
-        class="text-grey-400 uppercase text-xs font-light border-b-2 border-grey-500"
-      >
-        <tr>
-          <th
-            v-for="field in displayedFields"
-            :key="field.key"
-            class="p-3"
-            :class="{
-              'cursor-pointer hover:text-grey-500': field.sortable,
-              'p-2': dense,
-            }"
-            @click="field.sortable ?? sort(field.key)"
-          >
-            <slot :name="`head(${field.key})`" :field="field">
-              <div class="flex gap-2">
-                {{ field.label }}
-                <img
-                  v-if="field.sortable"
-                  src="/img/icon-sort.svg"
-                  alt="Icon sort"
-                />
-              </div>
+  <div>
+    <div class="flex justify-between items-center">
+      <div class="w-full">
+        <slot name="header-left" />
+      </div>
+      <div class="flex items-center gap-3">
+        <slot name="header-right" />
+        <input
+          v-if="search"
+          v-model="inputSearch"
+          class="h-[32px] w-[170px] text-xxs border-grey-600 text-grey-400 placeholder:text-grey-400 bg-transparent font-inter"
+          placeholder="Search"
+          type="text"
+        />
+      </div>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="text-left w-full">
+        <colgroup>
+          <template v-for="field in displayedFields" :key="field.key">
+            <slot :name="`col(${field.key})`">
+              <col />
             </slot>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="item in sortedItems" :key="item.id">
-          <template v-for="key in displayedFieldKeys" :key="key">
-            <Component
-              :is="cellElement(key as string)"
-              class="p-3 text-grey-900 text-sm border-b border-dashed border-grey-500"
+          </template>
+        </colgroup>
+        <thead
+          class="text-grey-400 uppercase text-xs font-light border-b-2 border-grey-500"
+        >
+          <tr>
+            <th
+              v-for="field in displayedFields"
+              :key="field.key"
+              class="p-3"
               :class="{
+                'cursor-pointer hover:text-grey-500': field.sortable,
                 'p-2': dense,
               }"
+              @click="sort(field.key)"
             >
-              <slot
-                :name="`cell(${key})`"
-                :value="format(item, (key as string))"
-                :item="item"
-                :format="(k: string) => format(item, k)"
-              >
-                {{ format(item, key as string) }}
+              <slot :name="`head(${field.key})`" :field="field">
+                <div class="flex gap-2">
+                  {{ field.label }}
+                  <img
+                    v-if="field.sortable"
+                    src="/img/icon-sort.svg"
+                    alt="Icon sort"
+                  />
+                </div>
               </slot>
-            </Component>
-          </template>
-        </tr>
-        <tr v-if="loading || !items.length">
-          <td
-            :colspan="displayedFields.length"
-            class="p-3 text-grey-300 text-sm border-b border-dashed border-grey-500"
-          >
-            <div v-if="loading" class="flex items-center justify-center">
-              <MIconLoading /> Loading data...
-            </div>
-            <div v-else-if="!items.length">
-              <slot name="empty">No data to show.</slot>
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="item in searchedItems" :key="item.id">
+            <template v-for="key in displayedFieldKeys" :key="key">
+              <Component
+                :is="cellElement(key as string)"
+                class="p-3 text-sm border-b border-dashed border-grey-500"
+                :class="{
+                  'p-2': dense,
+                }"
+              >
+                <slot
+                  :name="`cell(${key})`"
+                  :value="format(item, (key as string))"
+                  :item="item"
+                  :format="(k: string) => format(item, k)"
+                >
+                  {{ format(item, key as string) }}
+                </slot>
+              </Component>
+            </template>
+          </tr>
+          <tr v-if="loading || !items.length">
+            <td
+              :colspan="displayedFields.length"
+              class="p-3 text-grey-300 text-sm border-b border-dashed border-grey-500"
+            >
+              <div v-if="loading" class="flex items-center justify-center">
+                <MIconLoading /> Loading data...
+              </div>
+              <div v-else-if="!items.length">
+                <slot name="empty">No data to show.</slot>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </template>
 
@@ -94,8 +111,10 @@ const props = defineProps({
   items: { type: Array as PropType<TableItem[]>, default: () => [] },
   dense: { type: Boolean, default: false },
   loading: { type: Boolean, default: false },
+  search: { type: Boolean, default: false },
 });
 
+const inputSearch = ref("");
 const sortKey = ref();
 const sortOrder = ref(1); // 1 for ascending, -1 for descending
 
@@ -126,22 +145,32 @@ const sort = (key: string) => {
   }
 };
 
-const sortedItems = computed(() => {
-  if (!sortKey.value) {
-    return props.items;
+const searchedItems = computed(() => {
+  let items = props.items;
+
+  if (inputSearch.value && props.search) {
+    items = items.filter((item) =>
+      Object.values(item).some((value) =>
+        String(value).toLowerCase().includes(inputSearch.value.toLowerCase())
+      )
+    );
   }
 
-  return [...props.items].sort((a, b) => {
-    const aValue = a[sortKey.value];
-    const bValue = b[sortKey.value];
+  if (sortKey.value) {
+    return [...items].sort((a, b) => {
+      const aValue = a[sortKey.value];
+      const bValue = b[sortKey.value];
 
-    if (aValue < bValue) {
-      return -1 * sortOrder.value;
-    } else if (aValue > bValue) {
-      return 1 * sortOrder.value;
-    } else {
-      return 0;
-    }
-  });
+      if (aValue < bValue) {
+        return -1 * sortOrder.value;
+      } else if (aValue > bValue) {
+        return 1 * sortOrder.value;
+      } else {
+        return 0;
+      }
+    });
+  }
+
+  return items;
 });
 </script>


### PR DESCRIPTION
Add search to MSimpleTable component and added more slots to control the table's header.

Usage:
```
<MSimpleTable :search="true" />
```

![image](https://github.com/MZero-Labs/ttg-frontend/assets/146194347/1bd1582d-8183-40c9-81d7-4cddd29fe296)
