### PR TITLE
WEB3 743 Add input validations to Delegate page

### DIFF
--- a/pages/delegate.vue
+++ b/pages/delegate.vue
@@ -24,7 +24,7 @@
 
     <form
       class="my-4 bg-grey-800 p-6 font-inter"
-      @submit.prevent="delegateVote"
+      @submit.prevent="delegatePower"
     >
       <div>
         <div class="flex justify-between items-center mb-3">
@@ -42,12 +42,13 @@
           </div>
         </div>
         <label class="text-grey-600">Delegation address</label>
-        <input
+        <MInput
           id="input-delegate-power"
-          v-model="inputPowerDelegates"
+          v-model="powerFormData.address"
           type="text"
-          class="w-full border border-gray-600 rounded p-4 mb-4"
+          class="w-full border border-gray-600 rounded p-4 mb-2"
           data-test="delegate-power-input-address"
+          :errors="$delegatePowerValidation.address?.$errors"
         />
 
         <div v-if="hasDelegatedPower" class="my-4 text-xs text-grey-600">
@@ -65,8 +66,9 @@
         <MButton
           id="button-delegate-power"
           type="submit"
-          :disabled="!isConnected || !canDelegate || !inputPowerDelegates"
+          :disabled="!isConnected || !canDelegate || !powerFormData.address"
           data-test="delegate-button-power-submit"
+          :is-loading="powerFormData.loading"
         >
           delegate
         </MButton>
@@ -75,7 +77,7 @@
 
     <form
       class="my-4 bg-grey-800 p-6 font-inter"
-      @submit.prevent="delegateValue"
+      @submit.prevent="delegateZero"
     >
       <div>
         <div class="flex justify-between items-center my-3">
@@ -93,12 +95,13 @@
           </div>
         </div>
         <label class="text-grey-600">Delegation address</label>
-        <input
+        <MInput
           id="input-delegate-zero"
-          v-model="inputZeroDelegates"
+          v-model="zeroFormData.address"
           type="text"
-          class="w-full border border-gray-600 rounded p-4 mb-4"
+          class="w-full border border-gray-600 rounded p-4 mb-2"
           data-test="delegate-zero-input-address"
+          :errors="$delegateZeroValidation.address?.$errors"
         />
 
         <div v-if="hasDelegatedZero" class="my-4 text-xs text-grey-600">
@@ -116,8 +119,9 @@
         <MButton
           id="button-delegate-zero"
           type="submit"
-          :disabled="!isConnected || !canDelegate || !inputZeroDelegates"
+          :disabled="!isConnected || !canDelegate || !zeroFormData.address"
           data-test="delegate-button-zero-submit"
+          :is-loading="zeroFormData.loading"
         >
           delegate
         </MButton>
@@ -133,15 +137,16 @@
 
 <script lang="ts" setup>
 import { storeToRefs } from "pinia";
-import { Hash } from "viem";
+import { Hash, isAddress } from "viem";
 import { useAccount } from "use-wagmi";
+import { helpers } from "@vuelidate/validators";
+import { useVuelidate } from "@vuelidate/core";
+import { waitForTransactionReceipt } from "@wagmi/core";
 import { useMBalances } from "@/lib/hooks";
 import { writePowerToken, writeZeroToken } from "@/lib/sdk";
 
 const spog = storeToRefs(useSpogStore());
-
-const inputPowerDelegates = ref();
-const inputZeroDelegates = ref();
+const alerts = useAlertsStore();
 
 const { address: userAccount, isConnected } = useAccount();
 
@@ -151,15 +156,36 @@ const { powerDelegates, zeroDelegates, hasDelegatedPower, hasDelegatedZero } =
 const { powerToken: balancePowerToken, zeroToken: balanceZeroToken } =
   useMBalances(userAccount);
 
-function onUseMyAddress(refAddress: Ref<string | undefined>) {
-  refAddress.value = userAccount.value!;
-}
-const onUseMyAddressVote = () => onUseMyAddress(inputPowerDelegates);
-const onUseMyAddressValue = () => onUseMyAddress(inputZeroDelegates);
+const onUseMyAddressVote = () => (powerFormData.address = userAccount.value!);
+const onUseMyAddressValue = () => (zeroFormData.address = userAccount.value!);
 
 const canDelegate = computed(
   () => spog.epoch.value.current.type === "TRANSFER"
 );
+
+const addressValidation = (val: Hash) => isAddress(val);
+
+const powerFormData = reactive({
+  address: "",
+  loading: false,
+});
+
+const zeroFormData = reactive({
+  address: "",
+  loading: false,
+});
+
+const addressRules = {
+  address: {
+    addressValidation: helpers.withMessage(
+      "Invalid address",
+      addressValidation
+    ),
+  },
+};
+
+const $delegatePowerValidation = useVuelidate(addressRules, powerFormData);
+const $delegateZeroValidation = useVuelidate(addressRules, zeroFormData);
 
 const { forceSwitchChain } = useCorrectChain();
 const wagmiConfig = useWagmiConfig();
@@ -168,23 +194,65 @@ useHead({
   titleTemplate: "%s - Delegate",
 });
 
-async function delegateVote() {
-  await forceSwitchChain();
+async function delegatePower() {
+  await $delegatePowerValidation.value.$validate();
+  if ($delegatePowerValidation.value.$error) return;
+  powerFormData.loading = true;
 
-  return writePowerToken(wagmiConfig, {
-    address: spog.contracts.value.powerToken as Hash,
-    functionName: "delegate",
-    args: [inputPowerDelegates.value! as Hash],
-  });
+  try {
+    await forceSwitchChain();
+
+    const hash = await writePowerToken(wagmiConfig, {
+      address: spog.contracts.value.powerToken as Hash,
+      functionName: "delegate",
+      args: [powerFormData.address! as Hash],
+    });
+
+    const txReceipt = await waitForTransactionReceipt(wagmiConfig, {
+      confirmations: 1,
+      hash,
+    });
+
+    if (txReceipt.status !== "success") {
+      throw new Error("Transaction was rejected");
+    } else {
+      alerts.successAlert(
+        `Power successfully delegated to ${powerFormData.address}.`
+      );
+    }
+  } finally {
+    powerFormData.loading = false;
+  }
 }
 
-async function delegateValue() {
-  await forceSwitchChain();
+async function delegateZero() {
+  await $delegateZeroValidation.value.$validate();
+  if ($delegateZeroValidation.value.$error) return;
+  zeroFormData.loading = true;
 
-  return writeZeroToken(wagmiConfig, {
-    address: spog.contracts.value.zeroToken as Hash,
-    functionName: "delegate",
-    args: [inputZeroDelegates.value! as Hash],
-  });
+  try {
+    await forceSwitchChain();
+
+    const hash = await writeZeroToken(wagmiConfig, {
+      address: spog.contracts.value.zeroToken as Hash,
+      functionName: "delegate",
+      args: [zeroFormData.address! as Hash],
+    });
+
+    const txReceipt = await waitForTransactionReceipt(wagmiConfig, {
+      confirmations: 1,
+      hash,
+    });
+
+    if (txReceipt.status !== "success") {
+      throw new Error("Transaction was rejected");
+    } else {
+      alerts.successAlert(
+        `Zero successfully delegated to ${powerFormData.address}.`
+      );
+    }
+  } finally {
+    zeroFormData.loading = false;
+  }
 }
 </script>


### PR DESCRIPTION
Added validations to Delegate page, both inputs with new validation with `isAddress` from `viem`. I also adjusted the spacing a little bit.

Success validation with notifications example:
![image](https://github.com/MZero-Labs/ttg-frontend/assets/146194347/a57cc7f8-0158-4182-9ec6-d8b0474e136c)

New validation comparison, same length of string but different result:
![image](https://github.com/MZero-Labs/ttg-frontend/assets/146194347/81618eb6-9612-4222-995c-7283e7cb495b)
