### PR TITLE
WEB3 698 proposals standard tab badge and design fix

### DIFF
--- a/components/design-system/MBadge.vue
+++ b/components/design-system/MBadge.vue
@@ -6,7 +6,7 @@
 
 <script lang="ts" setup>
 export interface MBadgeProps {
-  version?: "success" | "error";
+  version?: "success" | "error" | "info";
 }
 
 const props = withDefaults(defineProps<MBadgeProps>(), {
@@ -23,5 +23,8 @@ span {
 }
 .error {
   @apply bg-red-700 text-white;
+}
+.info {
+  @apply bg-white text-grey-900;
 }
 </style>

--- a/layouts/proposals.vue
+++ b/layouts/proposals.vue
@@ -40,7 +40,7 @@
             class="proposals-nav-button"
             data-test="button-tab-standard"
           >
-            Standard <MBadge>{{ standardProposals }}</MBadge>
+            Standard <MBadge version="info">{{ standardProposals }}</MBadge>
           </MNavButton>
         </NuxtLink>
 


### PR DESCRIPTION
Tabs badge for standard proposals with counter and design of all badges fixed to look like design:

![image](https://github.com/MZero-Labs/ttg-frontend/assets/146194347/47125d2e-77b3-4414-9387-bcdafc23c559)
