### PR TITLE
WEB3 805 executing state for proposals to show better in UI

### DIFF
--- a/components/proposal/Card.vue
+++ b/components/proposal/Card.vue
@@ -110,8 +110,8 @@
           <MButton
             id="button-proposal-execute"
             data-test="proposal-button-execute"
-            :disabled="isDisconnected || isLoading"
-            :is-loading="isLoading"
+            :disabled="isDisconnected || proposal.executing"
+            :is-loading="proposal.executing"
             @click="onExecuteProposal()"
           >
             Execute

--- a/lib/api/modules/governor/modules/proposal/proposal.types.ts
+++ b/lib/api/modules/governor/modules/proposal/proposal.types.ts
@@ -34,6 +34,7 @@ export interface MProposalMutable {
   state: MProposalState;
   noVotes: bigint;
   yesVotes: bigint;
+  executing: boolean;
 }
 
 export interface MProposal extends ProposalEventLog, MProposalMutable {

--- a/pages/proposals/succeeded.vue
+++ b/pages/proposals/succeeded.vue
@@ -45,7 +45,7 @@ async function onExecute(proposal: MProposal) {
   const targets = [governor?.address as Hash];
   const values = [BigInt(0)]; // do not change
 
-  isLoading.value = true;
+  proposalStore.updateProposalByKey(proposal.proposalId, "executing", true);
   try {
     const hash = await writeContract(wagmiConfig, {
       abi: governor!.abi as Abi,
@@ -72,7 +72,7 @@ async function onExecute(proposal: MProposal) {
     console.error("Error executing proposal", error);
     alerts.errorAlert("Error while executing proposal");
   } finally {
-    isLoading.value = false;
+    proposalStore.updateProposalByKey(proposal.proposalId, "executing", false);
   }
 }
 </script>

--- a/stores/proposals.ts
+++ b/stores/proposals.ts
@@ -73,10 +73,8 @@ export const useProposalsStore = defineStore("proposals", {
     updateProposalByKey(proposalId: string, key: keyof MProposal, value: any) {
       const proposalStore = this.data.find((p) => p.proposalId === proposalId);
       if (proposalStore) {
-        if (has(proposalStore, key)) {
-          const newProposal = { ...proposalStore, [key]: value } as MProposal;
-          this.update(newProposal);
-        }
+        const newProposal = { ...proposalStore, [key]: value } as MProposal;
+        this.update(newProposal);
       }
     },
 


### PR DESCRIPTION
Problem to solve is that we have only a general executing state for pending proposals, so when user starts executing one proposal, all show an executing state and all buttons become disable. Video in ticket:
https://mzerolabs.atlassian.net/browse/WEB3-805

Fixed version with individual `executing` state for each proposal:

https://github.com/MZero-Labs/ttg-frontend/assets/146194347/fb4ccbdf-7716-4935-946e-ad5e4f550554

