### PR TITLE
WEB3 919 Update fees page UI with adjusted button spacing and disable

### DIFF
--- a/pages/fees.vue
+++ b/pages/fees.vue
@@ -21,7 +21,7 @@
       <h3 class="text-sm font-inter text-grey-200 mb-3">
         Total amount to be distributed among all holders
       </h3>
-      <div class="flex flex-wrap gap-4 lg:gap-8">
+      <div class="flex flex-wrap gap-6 lg:gap-12">
         <MIconLoading v-if="loadingData" />
         <div v-for="(token, i) in cashTokens" v-else :key="token.address">
           <span class="token-label">{{ token.name }}</span>
@@ -32,9 +32,9 @@
             size="20"
           />
           <MButton
-            class="mt-4"
+            class="distribute-button"
             :is-loading="token.isDistributing"
-            :disabled="token.isDistributing"
+            :disabled="token.isDistributing || token.distributable === 0n"
             @click="distributeRewards(token, i)"
           >
             Distribute
@@ -233,5 +233,8 @@ const claimTokenRewards = async (token, index) => {
 <style>
 .token-label {
   @apply text-grey-500 text-xxs font-inter mb-1;
+}
+.distribute-button {
+  @apply mt-4 text-xs !important;
 }
 </style>


### PR DESCRIPTION
Distribute buttons spacing, size and disabled when there is nothing to distribute

OLD:
![image](https://github.com/MZero-Labs/ttg-frontend/assets/146194347/63483282-2e60-4e63-9ced-090f5a21542e)

NEW:
![image](https://github.com/MZero-Labs/ttg-frontend/assets/146194347/f9595cbe-6411-4410-aff7-2465b2436e98)
