### PR TITLE
Fix/remove extra guidances

### DIFF
--- a/components/modal/ModalEthWrapper.vue
+++ b/components/modal/ModalEthWrapper.vue
@@ -13,7 +13,7 @@
         <div ref="dialog" class="p-6 bg-grey-800">
           <div class="mb-2 text-xl flex items-center justify-between">
             <span>Convert ETH to WETH</span>
-            <button>
+            <button @click="show = false">
               <img src="/img/modals/close.svg" alt="" srcset="" />
             </button>
           </div>

--- a/cypress/e2e/basic/basic_protocol_configuration.cy.ts
+++ b/cypress/e2e/basic/basic_protocol_configuration.cy.ts
@@ -44,12 +44,6 @@ describe("Basic configuration", () => {
 
     const configParams = [
       "Guidance",
-      "Ecosystem Guidance",
-      "Collateral Guidance",
-      "SPV Operators Guidance",
-      "Validators Guidance",
-      "Minters Guidance",
-      "Mandatory Contract Clauses Guidance",
     ]
 
     cy.get('h3.text-xl').should('have.length', configParams.length)

--- a/lib/api/modules/registrar/protocol-configs/protocol-configs.ts
+++ b/lib/api/modules/registrar/protocol-configs/protocol-configs.ts
@@ -19,12 +19,6 @@ export class ProtocolConfigs extends ApiModule {
     "base_minter_rate",
     "max_earner_rate",
     "guidance",
-    "ecosystem_guidance",
-    "collateral_guidance",
-    "spv_operators_guidance",
-    "validators_guidance",
-    "minters_guidance",
-    "mandatory_contract_guidance",
   ];
 
   keysInAddress = ["minter_rate_model", "earner_rate_model"];


### PR DESCRIPTION
Remove extra guidances, at least temporary, the description is left but is not processed or shown in the config list.
Sending also fix for eth to weth modal not closing when clicking in X button.

![image](https://github.com/user-attachments/assets/731c7b3e-7440-4ae0-8163-1a00eaadf7af)
