### PR TITLE
WEB3 1079 Fix checksum error in profile page voting table

### DIFF
--- a/components/profile/Tables.vue
+++ b/components/profile/Tables.vue
@@ -50,7 +50,7 @@ const votesStore = useVotesStore();
 watch(
   address,
   () => {
-    votes = votesStore.getBy("voter", address.value);
+    votes = votesStore.getByAddress(address.value);
   },
   { immediate: true },
 );

--- a/stores/votes.ts
+++ b/stores/votes.ts
@@ -1,6 +1,7 @@
 import uniqBy from "lodash/uniqBy";
 import { MVote } from "@/lib/api/types";
 import { defineStore } from "pinia";
+import { Hash } from "viem";
 
 export const useVotesStore = defineStore("votes", () => {
   const api = useApiClientStore();
@@ -9,6 +10,14 @@ export const useVotesStore = defineStore("votes", () => {
 
   function getBy(key: keyof MVote, value: string) {
     return computed(() => votes.value.filter((v) => v[key] === value));
+  }
+
+  function getByAddress(address: Hash) {
+    return computed(() =>
+      votes.value.filter(
+        (v) => v.voter?.toLowerCase() === address.toLowerCase(),
+      ),
+    );
   }
 
   function add(newVotes: MVote[]) {
@@ -57,6 +66,7 @@ export const useVotesStore = defineStore("votes", () => {
     fetchVotesZero,
     fetchVotes,
     getBy,
+    getByAddress,
     add,
   };
 });


### PR DESCRIPTION
Fix checksum error when retrieving data for voting table. To test this edge case you need to insert an `address` in lower case to profile page `/profile/[address]`

Report:
![image](https://github.com/user-attachments/assets/d0185c29-bd44-40f2-af06-2e2258cb9c4f)

FIX:
![image](https://github.com/user-attachments/assets/73c01b3a-b474-41a5-83c5-4ef96984b761)

OLD:
![image](https://github.com/user-attachments/assets/1300128b-64a8-4e03-9fcf-0b285fc79ae5)
