### PR TITLE
WEB3 1128 all proposals sidebar link and adapted design

### DIFF
--- a/components/layout/LayoutSidebar.vue
+++ b/components/layout/LayoutSidebar.vue
@@ -52,7 +52,7 @@
                 :to="item.path"
                 :class="{
                   'notification-dot': item.notification,
-                  active: currentRoute?.path?.includes(item.path),
+                  active: currentRoute?.path === item.path,
                 }"
                 :data-test="item.dataTest"
               >
@@ -74,7 +74,7 @@
                 :to="item.path"
                 :class="{
                   'notification-dot': item?.notification,
-                  active: currentRoute?.path?.includes(item.path),
+                  active: currentRoute?.path === item.path,
                 }"
                 :data-test="item.dataTest"
               >
@@ -206,6 +206,12 @@ const mainMenuItems = computed(() => {
       path: "/proposals/",
       isShow: isAuctionNotActive.value,
       dataTest: "sidebar-link-proposals",
+    },
+    {
+      title: "All proposals",
+      path: "/proposals/all",
+      isShow: isAuctionNotActive.value,
+      dataTest: "sidebar-link-all-proposals",
     },
     {
       title: "Actors",

--- a/cypress/e2e/basic/basic_navigation.cy.ts
+++ b/cypress/e2e/basic/basic_navigation.cy.ts
@@ -8,13 +8,13 @@ describe("Basic navigation", () => {
     cy.findByRole("button", {name: /Create proposal/i}).should("be.visible");
 
     cy.get("nav").should("contain", "Home");
+    cy.get("nav").should("contain", "All proposals");
     cy.get("nav").should("contain", "Actors");
     cy.get("nav").should("contain", "Configs");
   });
 
   it("I should see all proposals page", () => {
-    cy.findByRole("button", {name: /All proposals/i}).click();
-    cy.url().should("include", "/proposals/all");
+    cy.visit("/proposals/all");
 
     cy.get("h1").should("have.length", 1);
     cy.get("h1").should("contain.text", "All proposals");

--- a/layouts/proposals.vue
+++ b/layouts/proposals.vue
@@ -38,15 +38,6 @@
             </div>
           </div>
         </template>
-        <template #side>
-          <NuxtLink to="/proposals/all/">
-            <MNavButton
-              class="text-sm font-ppformula underline normal-case text-grey-500"
-            >
-              All proposals
-            </MNavButton>
-          </NuxtLink>
-        </template>
       </PageTitle>
     </div>
 

--- a/pages/proposals/all.vue
+++ b/pages/proposals/all.vue
@@ -95,7 +95,6 @@ const proposals = computed(() => store.data);
 
 const selectedType = ref("all");
 const selectedEpoch = ref(0);
-const selectedStatus = ref("all");
 
 const proposalsTableHeader = [
   { key: "epoch", label: "Created Epoch", sortable: true },
@@ -112,10 +111,6 @@ const epochNumbers = computed(() => [
   ...new Set(proposals.value.map((obj) => obj.epoch)),
 ]);
 
-const statusTypes = computed(() => [
-  ...new Set(proposals.value.map((obj) => obj.state)),
-]);
-
 const filteredProposals = computed(() => {
   let results = proposals.value;
 
@@ -124,9 +119,6 @@ const filteredProposals = computed(() => {
 
   if (selectedEpoch.value !== 0)
     results = results.filter((obj) => obj.epoch === selectedEpoch.value);
-
-  if (selectedStatus.value !== "all")
-    results = results.filter((obj) => obj.state === selectedStatus.value);
 
   return results;
 });

--- a/pages/proposals/all.vue
+++ b/pages/proposals/all.vue
@@ -7,14 +7,6 @@
     >
       <template #header-left>
         <PageTitle>
-          <template #pretitle>
-            <NuxtLink
-              class="text-green-700 hover:text-green-600 text-sm uppercase cursor-pointer"
-              to="/proposals"
-            >
-              Back
-            </NuxtLink>
-          </template>
           <template #default>All proposals</template>
         </PageTitle>
       </template>
@@ -24,9 +16,9 @@
         >
           <select
             v-model="selectedType"
-            class="h-[32px] w-[170px] bg-transparent text-grey-100 text-xxs p-0 px-2"
+            class="h-[32px] w-[170px] bg-transparent text-grey-100 text-xs p-0 px-2"
           >
-            <option value="all" default>All proposals</option>
+            <option value="all" default>All proposal types</option>
             <option
               v-for="option in proposalTypes"
               :key="option"
@@ -37,7 +29,7 @@
           </select>
           <select
             v-model="selectedEpoch"
-            class="h-[32px] w-[170px] bg-transparent text-grey-100 text-xxs p-0 px-2"
+            class="h-[32px] w-[170px] bg-transparent text-grey-100 text-xs p-0 px-2"
           >
             <option :value="0" default>All epochs</option>
             <option
@@ -45,16 +37,6 @@
               :key="option"
               :value="option"
             >
-              {{ option }}
-            </option>
-          </select>
-
-          <select
-            v-model="selectedStatus"
-            class="h-[32px] w-[170px] bg-transparent text-grey-100 text-xxs p-0 px-2"
-          >
-            <option value="all" default>All status</option>
-            <option v-for="option in statusTypes" :key="option" :value="option">
               {{ option }}
             </option>
           </select>


### PR DESCRIPTION
Added `all proposals` link to sidebar and adapt page to new design. Removed `all status` selector and `back` button.

NEW:
![image](https://github.com/user-attachments/assets/209125c9-21f8-4fc1-a565-c8eb313b59e9)


OLD:
![image](https://github.com/user-attachments/assets/5e4e1fb7-dc3c-4d4d-bf8d-b6c8e56a91e4)
