### PR TITLE
WEB3 1163 add destination checkbox and input to auction form

### DIFF
--- a/components/design-system/MInput.vue
+++ b/components/design-system/MInput.vue
@@ -1,7 +1,7 @@
 <template>
   <input v-bind="$attrs" v-model="value" :class="{ error: hasErrors }" />
 
-  <div class="text-red-500 text-xs my-2 h-4">
+  <div class="text-red-500 text-xs my-1 h-4 font-inter">
     <p v-for="error of props.errors" :key="error.$uid">
       {{ error.$message }}
     </p>
@@ -24,6 +24,6 @@ const hasErrors = computed(() => props.errors?.length);
 
 <style scoped>
 .error {
-  @apply border border-red-600;
+  @apply bg-transparent border border-red-600;
 }
 </style>


### PR DESCRIPTION
Added a `custom destination address` checkbox and input for the auction `buy` form. The input have _only valid address_ validation. Everything testnet in Sepolia.

![image](https://github.com/user-attachments/assets/f625bcca-1a98-42b3-a1b5-eeaf12e05576)
![image](https://github.com/user-attachments/assets/6ef81198-4b50-423b-8ff2-47fd34e06739)
