### PR TITLE
WEB3 1186 update logos names and names in Wrap page

### DIFF
--- a/pages/wrap.vue
+++ b/pages/wrap.vue
@@ -8,9 +8,9 @@
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <div class="bg-grey-800 p-6">
           <div class="flex items-center gap-6">
-            <img src="/img/tokens/m.svg" alt="M Token" class="w-10 h-10" />
+            <img src="/img/tokens/new-m.svg" alt="M Token" class="w-10 h-10" />
             <div>
-              <h2>M</h2>
+              <h2>$M</h2>
               <p class="text-grey-500">
                 Balance: {{ formatUnits(m.balance, 6) }}
               </p>
@@ -31,12 +31,12 @@
         <div class="bg-grey-800 p-6">
           <div class="flex items-center gap-6">
             <img
-              src="/img/tokens/m.svg"
-              alt="M Token"
-              class="w-10 h-10 rotate-180"
+              src="/img/tokens/wrapped-m.svg"
+              alt="Wrapped M Token"
+              class="w-10 h-10"
             />
             <div>
-              <h2>Wrapped M</h2>
+              <h2>Smart $M</h2>
               <p class="text-grey-500">
                 Balance: {{ formatUnits(wrappedM.balance, 6) }}
               </p>

--- a/public/img/tokens/new-m.svg
+++ b/public/img/tokens/new-m.svg
@@ -1,0 +1,4 @@
+<svg width="150" height="150" viewBox="0 0 150 150" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M75 150C116.421 150 150 116.421 150 75C150 33.5786 116.421 0 75 0C33.5786 0 0 33.5786 0 75C0 116.421 33.5786 150 75 150Z" fill="#07F7BD"/>
+<path d="M63 62V110H53V40H63L75 66.1L87 40H97V110H87V62L77.7 81.8H72.3L63 62Z" fill="black"/>
+</svg>

--- a/public/img/tokens/wrapped-m.svg
+++ b/public/img/tokens/wrapped-m.svg
@@ -1,0 +1,5 @@
+<svg width="150" height="150" viewBox="0 0 150 150" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M75 150C116.421 150 150 116.421 150 75C150 33.5786 116.421 0 75 0C33.5786 0 0 33.5786 0 75C0 116.421 33.5786 150 75 150Z" fill="#07F7BD"/>
+<path d="M65 88L65 40L75 40L75 110L65 110L53 83.9L41 110L31 110L31 40L41 40L41 88L50.3 68.2L55.7 68.2L65 88Z" fill="#058B63"/>
+<path d="M85 62V110H75V40H85L97 66.1L109 40H119V110H109V62L99.7 81.8H94.3L85 62Z" fill="black"/>
+</svg>


### PR DESCRIPTION
Update logos to new green M and Smart M.

![image](https://github.com/user-attachments/assets/a4cac530-dbf4-4275-a293-6f98478058b0)
