### PR TITLE
WEB3 1204 improve proposals title size and word-break

### DIFF
--- a/components/proposal/Card.vue
+++ b/components/proposal/Card.vue
@@ -28,13 +28,13 @@
         class="mb-4"
       />
 
-      <div class="mb-4">
-        <h2 class="text-2xl break-all">
+      <div class="mb-4 text-xl lg:text-2xl break-words">
+        <h3>
           {{ title }}
-        </h2>
+        </h3>
       </div>
 
-      <div class="text-grey-500 font-inter mb-4 break-words">
+      <div class="text-grey-500 max-lg:text-sm font-inter mb-4 break-words">
         {{ truncate(onlyDescription, { length: 450 }) }}
       </div>
 


### PR DESCRIPTION
Improve proposal's cards title and description text size and word-break

OLD/NEW:
<p float="left">
  <img src="https://github.com/user-attachments/assets/7ba98057-6d36-46f8-9560-0c619ae279c4" width="300" /> 
  <img src="https://github.com/user-attachments/assets/f6ae69f6-69fe-4d46-a378-4b802235aab5" width="300" />
</p>