### PR TITLE
Feat/web3 1193 create values and ranges

### DIFF
--- a/components/proposal/InputDynamic.vue
+++ b/components/proposal/InputDynamic.vue
@@ -34,7 +34,7 @@
 
     <div
       v-if="props.modelValueErrors?.length"
-      class="text-red-500 text-xs my-2 h-4"
+      class="text-red-500 text-xs my-2 h-4 font-inter"
     >
       <p v-for="error of props.modelValueErrors" :key="error.$uid">
         {{ error.$message }}
@@ -68,8 +68,8 @@ const value = useVModelWrapper<InputProps>(props, emit, "modelValue");
 const hasErrors = computed(() => props.modelValueErrors?.length);
 </script>
 
-<style>
+<style scoped>
 .error {
-  @apply border border-red-500;
+  @apply bg-transparent border border-red-500;
 }
 </style>

--- a/components/proposal/InputProtocolConfigOperation.vue
+++ b/components/proposal/InputProtocolConfigOperation.vue
@@ -94,7 +94,6 @@ const inputs = {
     component: InputDynamic,
     props: {
       decorator: "contract",
-      maska: masks.ethereumAddress,
     },
   },
 
@@ -102,7 +101,6 @@ const inputs = {
     component: InputDynamic,
     props: {
       decorator: "contract",
-      maska: masks.ethereumAddress,
     },
   },
 

--- a/components/proposal/InputProtocolConfigOperation.vue
+++ b/components/proposal/InputProtocolConfigOperation.vue
@@ -53,7 +53,7 @@ const inputs = {
   penalty_rate: {
     component: InputDynamic,
     props: {
-      decorator: "%",
+      decorator: "BPS",
       maska: masks.percentage,
     },
   },
@@ -77,7 +77,7 @@ const inputs = {
   mint_ratio: {
     component: InputDynamic,
     props: {
-      decorator: "%",
+      decorator: "BPS",
       maska: masks.percentage,
     },
   },
@@ -109,7 +109,7 @@ const inputs = {
   base_minter_rate: {
     component: InputDynamic,
     props: {
-      decorator: "%",
+      decorator: "BPS",
       maska: masks.percentage,
     },
   },
@@ -117,7 +117,7 @@ const inputs = {
   max_earner_rate: {
     component: InputDynamic,
     props: {
-      decorator: "%",
+      decorator: "BPS",
       maska: masks.percentage,
     },
   },

--- a/components/proposal/Preview.vue
+++ b/components/proposal/Preview.vue
@@ -15,7 +15,7 @@
       </h2>
 
       <div
-        class="text-grey-400 my-1 font-inter text-xs truncate w-52 lg:w-full"
+        class="text-grey-500 my-1 font-inter text-xs truncate w-52 lg:w-full"
       >
         Proposed by
         <u><MAddressAvatar :address="proposal?.proposer" /></u>

--- a/cypress/e2e/basic-emergency/proposals-emergency-setKey-protocol-config.cy.ts
+++ b/cypress/e2e/basic-emergency/proposals-emergency-setKey-protocol-config.cy.ts
@@ -1,6 +1,6 @@
 describe("Proposals", () => {
   describe("type action: Emergency setKey", () => {
-    const value = "1";
+    const value = "60";
     const key = "mint_delay";
     const description = `Add config ${key} = ${value}`;
     let proposalUrl = "";

--- a/pages/proposal/create.vue
+++ b/pages/proposal/create.vue
@@ -930,34 +930,30 @@ function buildCalldatasTtg(functionName: any, args: any) {
 }
 
 function getKeyBasedValidation(key: string) {
-  if (["minter_rate_model", "earner_rate_model"].includes(key)) {
-    return { required, address: validations.address };
+  switch (key) {
+    case "minter_rate_model":
+    case "earner_rate_model":
+      return { required, address: validations.address };
+    case "base_minter_rate":
+    case "max_earner_rate":
+      return { required, range: validations.range(1, 5000) };
+    case "penalty_rate":
+      return { required, range: validations.range(1, 1000) };
+    case "update_collateral_interval":
+      return { required, range: validations.range(60, 31536000) }; // 1 minute to 1 year
+    case "update_collateral_threshold":
+      return { required, range: validations.range(1, 10) };
+    case "mint_delay":
+      return { required, range: validations.range(60, 86400) }; // 1 minute to 1 day
+    case "mint_ttl":
+      return { required, range: validations.range(3600, 864000) }; // 1 hour to 10 days
+    case "mint_ratio":
+      return { required, range: validations.range(50, 100) }; // Percent range
+    case "minter_freeze_time":
+      return { required, range: validations.range(3600, 2592000) }; // 1 hour to 1 month
+    default:
+      return { required };
   }
-  if (["base_minter_rate", "max_earner_rate"].includes(key)) {
-    return { required, range: validations.range(1, 5000) };
-  }
-  if (["penalty_rate"].includes(key)) {
-    return { required, range: validations.range(1, 1000) };
-  }
-  if (["update_collateral_interval"].includes(key)) {
-    return { required, range: validations.range(60, 31536000) }; // 1 minute to 1 year
-  }
-  if (["update_collateral_threshold"].includes(key)) {
-    return { required, range: validations.range(1, 10) };
-  }
-  if (["mint_delay"].includes(key)) {
-    return { required, range: validations.range(60, 86400) }; // 1 minute to 1 day
-  }
-  if (["mint_ttl"].includes(key)) {
-    return { required, range: validations.range(3600, 864000) }; // 1 hour to 10 days
-  }
-  if (["mint_ratio"].includes(key)) {
-    return { required, range: validations.range(50, 100) }; // Percent range
-  }
-  if (["minter_freeze_time"].includes(key)) {
-    return { required, range: validations.range(3600, 2592000) }; // 1 hour to 1 month
-  }
-  return { required };
 }
 
 function onBack() {

--- a/pages/proposal/create.vue
+++ b/pages/proposal/create.vue
@@ -854,20 +854,6 @@ function buildCalldatas(formData) {
         return addressToHexWith32Bytes(inp);
       }
 
-      if (
-        [
-          "penalty_rate",
-          "mint_ratio",
-          "base_minter_rate",
-          "max_earner_rate",
-        ].includes(key)
-      ) {
-        return encodeAbiParameters(
-          [{ type: "uint256" }],
-          [BigInt(percentageToBasispoints(inp))],
-        );
-      }
-
       return encodeAbiParameters([{ type: "uint256" }], [BigInt(inp)]);
     };
 


### PR DESCRIPTION
Add key-based validations in inputs for `Protocol config update` proposals.
Address validations are based in Viem's `isAddress` and not length.

Based in the following table:
Protocol Parameters | Range of values
-- | --
update_collateral_interval | [1 minute, 1 year] |  
update_collateral_threshold | [1, 10] | Advanced logic - check total number of validators in the system for the max boundary of the range
penalty_rate | [1, 1000] |  
mint_delay | [1 minute, 1 day] |  
mint_ttl | [1 hour, 10 days] |  
mint_ratio | [50%, 100%] |  
minter_freeze_time | [1 hour, 1 month]
base_minter_rate | [1, 5000]
max_earner_rate | [1, 5000]
minter_rate_model | address
earner_rate_model | address

Rate models:
![image](https://github.com/user-attachments/assets/bf81bb5d-e496-4d14-b341-97b944a27182)
Ranges:
![image](https://github.com/user-attachments/assets/de26220d-b7e7-48b3-b54d-cbe023b9bf73)
Time:
![image](https://github.com/user-attachments/assets/40b5f975-0867-4a09-b764-37a493fd0f15)

