### PR TITLE
WEB3 1307 Priority add claimant in create proposal flow

### DIFF
--- a/pages/proposal/create.vue
+++ b/pages/proposal/create.vue
@@ -595,6 +595,18 @@ const proposalTypes = [
         hasToPayFee: false,
         id: "emergencyGuidanceSetKey",
       },
+
+      {
+        value: "setKeyAddClaimant",
+        label: "Add claimant",
+        component: InputProtocolEarnerClaimant,
+        votingType: "Emergency",
+        governor: ttg.contracts.emergencyGovernor,
+        abi: emergencyGovernorAbi,
+        isEmergency: true,
+        hasToPayFee: false,
+        id: "emergencyProtocolAddClaimant",
+      },
     ],
   },
 


### PR DESCRIPTION
Priority `Add claimant` in create proposal flow.


### Testing example
Claimant: 0x14521ECf225E912Feb2C7827CA79Ea13a744d8d5
Earner: 0x942AeF058cb15C9b8b89B57B4E607d464ed8Cd33

Result in both Governors: 0x076ce5b84f1ba0d8e9fdeee08f5bbf569e2c24e0927487e16b39fa37ae9bbff6
Link to proposals [here](https://dev-governance.m0.org/proposals/all)

Standard
![image](https://github.com/user-attachments/assets/a9944415-f04f-49b9-b6e4-52b2c2d16778)

Priority
![image](https://github.com/user-attachments/assets/1f0c28ac-98ad-448e-a2df-47f0189ccd2e)
