### PR TITLE
ops: set NUXT_UI_PRO_LICENSE env value

### DIFF
--- a/.github/workflows/s3_buckets_build_and_upload_production_auction.yml
+++ b/.github/workflows/s3_buckets_build_and_upload_production_auction.yml
@@ -19,6 +19,7 @@ jobs:
       VITE_APP_RPC_URL_FALLBACK: ${{ secrets.VITE_APP_RPC_URL_FALLBACK }}
       VITE_APP_IS_AUCTION_ACTIVE: ${{ secrets.VITE_APP_IS_AUCTION_ACTIVE }}
       VITE_APP_WALLET_CONNECT_PROJECT_ID: ${{ secrets.VITE_APP_WALLET_CONNECT_PROJECT_ID }}
+      NUXT_UI_PRO_LICENSE: ${{ secrets.NUXT_UI_PRO_LICENSE }}
     steps:
 
       # Checking out the GitHub repository on the runner

--- a/.github/workflows/s3_buckets_build_and_upload_production_governance.yml
+++ b/.github/workflows/s3_buckets_build_and_upload_production_governance.yml
@@ -19,6 +19,7 @@ jobs:
       VITE_APP_RPC_URL_FALLBACK: ${{ secrets.VITE_APP_RPC_URL_FALLBACK }}
       VITE_APP_IS_AUCTION_ACTIVE: ${{ secrets.VITE_APP_IS_AUCTION_ACTIVE }}
       VITE_APP_WALLET_CONNECT_PROJECT_ID: ${{ secrets.VITE_APP_WALLET_CONNECT_PROJECT_ID }}
+      NUXT_UI_PRO_LICENSE: ${{ secrets.NUXT_UI_PRO_LICENSE }}
     steps:
 
       # Checking out the GitHub repository on the runner

--- a/.github/workflows/s3_buckets_build_and_upload_staging.yml
+++ b/.github/workflows/s3_buckets_build_and_upload_staging.yml
@@ -19,6 +19,7 @@ jobs:
       VITE_APP_RPC_URL_FALLBACK: ${{ secrets.VITE_APP_RPC_URL_FALLBACK }}
       VITE_APP_IS_AUCTION_ACTIVE: ${{ secrets.VITE_APP_IS_AUCTION_ACTIVE }}
       VITE_APP_WALLET_CONNECT_PROJECT_ID: ${{ secrets.VITE_APP_WALLET_CONNECT_PROJECT_ID }}
+      NUXT_UI_PRO_LICENSE: ${{ secrets.NUXT_UI_PRO_LICENSE }}
     steps:
 
       # Checking out the GitHub repository on the runner


### PR DESCRIPTION
populate changes to `main` so the workflow (which is pulled from main – [see](https://github.com/m0-foundation/ttg-frontend/blob/52ce628ceee6292c972822df0207459bb88bea09/.github/workflows/s3_buckets_deploy_production_governance.yml#L8)) can get it 