### PR TITLE
refactor(git-flow): use main as production branch. Introduce develop 

### DIFF
--- a/.github/workflows/s3_buckets_deploy_dev.yml
+++ b/.github/workflows/s3_buckets_deploy_dev.yml
@@ -3,13 +3,13 @@ name: Build & Upload to S3 DEV
 on:
   push:
     branches:
-      - 'main'
+      - 'develop'
   workflow_dispatch:
 
 jobs:
   deploy-dev:
-    uses: m0-foundation/ttg-frontend/.github/workflows/s3_buckets_build_and_upload_dev.yml@main
+    uses: m0-foundation/ttg-frontend/.github/workflows/s3_buckets_build_and_upload_dev.yml@develop
     secrets: inherit
     permissions:
       contents: write
-    if: github.ref_name == 'main'
+    if: github.ref_name == 'develop'

--- a/.github/workflows/s3_buckets_deploy_production_governance.yml
+++ b/.github/workflows/s3_buckets_deploy_production_governance.yml
@@ -1,4 +1,4 @@
-name: Build & Upload to PROD GOVERNANCE
+name: Build & Upload to PROD Governance
 
 on:
   workflow_dispatch:
@@ -9,11 +9,11 @@ jobs:
     secrets: inherit
     permissions:
       contents: write
-    if: github.ref_name == 'production'
+    if: github.ref_name == 'main'
 
   # Invoking, in case of successful build of "build-and-upload-to-s3-production", the sub-workflow that will create a tag
   tag:
-    if: success() && github.ref_name == 'production'
+    if: success() && github.ref_name == 'main'
     needs: [ deploy-production-governance ]
     uses: m0-foundation/ttg-frontend/.github/workflows/tag.yml@main
     permissions:
@@ -21,7 +21,7 @@ jobs:
 
   # Invoking, in case of successful build of "build-and-upload-to-s3-production" and "tag", the sub-workflow that will create a release
   release:
-    if: success() && github.ref_name == 'production'
+    if: success() && github.ref_name == 'main'
     needs: [ deploy-production-governance, tag ]
     uses: m0-foundation/ttg-frontend/.github/workflows/release.yml@main
     permissions:

--- a/.github/workflows/s3_buckets_deploy_staging.yml
+++ b/.github/workflows/s3_buckets_deploy_staging.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy-staging:
-    uses: m0-foundation/ttg-frontend/.github/workflows/s3_buckets_build_and_upload_staging.yml@main
+    uses: m0-foundation/ttg-frontend/.github/workflows/s3_buckets_build_and_upload_staging.yml@staging
     secrets: inherit
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -214,3 +214,81 @@ git fetch
 ```
 
 try push it again.
+
+
+## 🤝 Contributing
+
+- `main` reflects the production-ready state.
+- `develop`, reflects the state with the latest delivered development changes for the next release.
+
+Below you will a guide for the most common scenarios. Please refer to [Git Flow](https://nvie.com/posts/a-successful-git-branching-model/) for a more in-depth explanation.
+
+### Feature branches
+
+We use feature branches to develop new features or fix existing ones.
+
+- Branch off from: `develop`
+- Must merge back into: `develop`
+- Branch naming convention: `WEB3-1234/scope-of-the-changes-or-ticket-title`. Where WEB3-1234 matches the Jira ticket.
+- Open a pull request to incorporate your changes back to `develop`.
+- ⚠️ Merge strategy: Squash and merge.
+
+### Release branches
+
+Release branches are used for production deployments.
+
+- Branch off from: `develop`
+- Must merge back into: `main` **and** `develop`
+- Branch naming convention: `release/x.x.x`. Where `x.x.x` is the release version.
+- ⚠️ Merge strategy: Merge commit.
+
+1. Create a new release branch
+
+   ```sh
+   git fetch
+   git checkout -b release/x.x.x origin/develop
+   ```
+
+1. Bump the version in `package.json`, `apps/server/package.json`, and `apps/web/package.json`. The release naming must match the version.
+
+1. Push your changes to GitHub and open a pull request against `main`.
+
+1. Wait for the pull request to get approved. Use a "Merge commit" to merge the pull request.
+
+1. Let the team know about the upcoming deploy.
+
+1. Run the workflow [Build & Upload to PROD Governance](https://github.com/m0-foundation/ttg-frontend/actions/workflows/s3_buckets_deploy_production_governance.yml) targeting the `main` branch.
+
+1. Monitor the action, and let the team know once changes are live.
+
+1. Populate the release to `develop`
+
+   ```sh
+   git checkout develop
+   git pull origin develop
+
+   # merge into develop
+   git merge --no-ff release/x.x.x
+
+   git push origin develop
+   ```
+
+1. The branch `release/x.x.x` can now be deleted in GitHub.
+
+
+### Hotfix
+
+Hotfix branch is used to patch or fix something in production.
+
+- Branch off from: `main`
+- Must merge back into: `main` **and** `develop`, **and** any outgoing `release/x.x.x` branch.
+- Branch naming convention: `hotfix/x.x.x`. Where `x.x.x` is the release version.
+- ⚠️ Merge strategy: Merge commit.
+
+Releasing the hotfix branch involves the same steps as a `release/*` branch. Including version bumping. Refer to the section above for detailed steps.
+
+
+### Additional guidelines
+- Git commits: We follow (non-strictly) [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
+- Pull requests: The title follows conventional commits as well. Description is a must. Please include screenshots or videos for visual changes, testing evidence and any other relevant information for reviewers. Explain why and what changed not how.
+- Approvals: Get at least one approval.


### PR DESCRIPTION
We want to follow Git Flow more explicitly to ease onboarding in our projects. This changes set `main` as the production branch and introduce `develop`.

## TODO
@conradocanasm0 , I need you on these tasks:

- [ ] Create the `develop` branch off the `main` branch.
- [ ] Set `develop` as the base branch in Github.