### PR TITLE
feat: persistent voting selection

### DIFF
--- a/components/proposal/Card.vue
+++ b/components/proposal/Card.vue
@@ -185,7 +185,6 @@ import errorProposals from "@/assets/data/error-proposals.json";
 
 export interface ProposalCardProps {
   proposal: MProposal;
-  selectedVote: boolean | null;
   loading: boolean;
 }
 
@@ -199,9 +198,18 @@ const emit = defineEmits<{
 }>();
 
 const apiStore = useApiClientStore();
-
+const localSelectedVotes = useLocalSelectedVotes();
 const { address: userAccount, isConnected, isDisconnected } = useAccount();
 
+const localStoredVote = localSelectedVotes.get(props.proposal.proposalId);
+const initialSelectedVote =
+  localStoredVote?.vote != null
+    ? localStoredVote.vote === 0
+      ? false
+      : true
+    : null;
+
+const selectedVote = ref<null | boolean>(initialSelectedVote);
 const selectedVote = ref<null | boolean>(props.selectedVote);
 const reasonForVoteCheckbox = ref<boolean | undefined>(false);
 const reasonForVote = ref<string>("");

--- a/components/proposal/Card.vue
+++ b/components/proposal/Card.vue
@@ -185,6 +185,7 @@ import errorProposals from "@/assets/data/error-proposals.json";
 
 export interface ProposalCardProps {
   proposal: MProposal;
+  selectedVote: boolean | null;
   loading: boolean;
 }
 
@@ -201,7 +202,7 @@ const apiStore = useApiClientStore();
 
 const { address: userAccount, isConnected, isDisconnected } = useAccount();
 
-const selectedVote = ref<null | boolean>(null);
+const selectedVote = ref<null | boolean>(props.selectedVote);
 const reasonForVoteCheckbox = ref<boolean | undefined>(false);
 const reasonForVote = ref<string>("");
 const reasonForVoteTextarea = ref();

--- a/components/proposal/Card.vue
+++ b/components/proposal/Card.vue
@@ -146,7 +146,6 @@
         <div>
           <UTextarea
             v-if="reasonForVoteCheckbox"
-            id="reason-vote"
             ref="reasonForVoteTextarea"
             :value="localStoredVote?.reason || ''"
             class="reason-textarea"
@@ -227,10 +226,11 @@ const reasonForVoteTextarea = ref();
 
 watch(reasonForVoteCheckbox, async (value) => {
   if (value) {
+    // Focus the textarea when enabled
     await nextTick();
-    // FIXME
-    reasonForVoteTextarea?.value.focus();
+    reasonForVoteTextarea.value?.focus();
   } else {
+    // Clean reason when disabled
     emit("update-reason-for-vote", "", props.proposal.proposalId);
   }
 });

--- a/components/proposal/Card.vue
+++ b/components/proposal/Card.vue
@@ -203,16 +203,13 @@ const { address: userAccount, isConnected, isDisconnected } = useAccount();
 
 const localStoredVote = localSelectedVotes.get(props.proposal.proposalId);
 const initialSelectedVote =
-  localStoredVote?.vote != null
-    ? localStoredVote.vote === 0
-      ? false
-      : true
-    : null;
+  localStoredVote != null ? (localStoredVote.vote === 0 ? false : true) : null;
 
 const selectedVote = ref<null | boolean>(initialSelectedVote);
-const selectedVote = ref<null | boolean>(props.selectedVote);
-const reasonForVoteCheckbox = ref<boolean | undefined>(false);
-const reasonForVote = ref<string>("");
+const reasonForVoteCheckbox = ref<boolean | undefined>(
+  Boolean(localStoredVote?.reason),
+);
+const reasonForVote = ref<string>(localStoredVote?.reason || "");
 const reasonForVoteTextarea = ref();
 
 watch(reasonForVoteCheckbox, async (value) => {

--- a/components/proposal/List.vue
+++ b/components/proposal/List.vue
@@ -5,6 +5,7 @@
       <ProposalCard
         :loading="loading"
         :proposal="proposal"
+        :selected-vote="selectedVotes.get(proposal.proposalId)"
         v-bind="$attrs"
         @on-view="onViewProposal"
       />
@@ -27,6 +28,7 @@ export interface ProposalListProps {
 
 const props = defineProps<ProposalListProps>();
 const { proposals } = toRefs(props);
+const selectedVotes = useLocalSelectedVotes();
 
 const hasProposals = computed(
   () => proposals.value && proposals.value.length > 0,

--- a/components/proposal/List.vue
+++ b/components/proposal/List.vue
@@ -5,7 +5,6 @@
       <ProposalCard
         :loading="loading"
         :proposal="proposal"
-        :selected-vote="selectedVotes.get(proposal.proposalId)"
         v-bind="$attrs"
         @on-view="onViewProposal"
       />
@@ -23,12 +22,10 @@ import { MProposal } from "@/lib/api/types";
 export interface ProposalListProps {
   proposals: MProposal[];
   loading: boolean;
-  selectedProposal?: string;
 }
 
 const props = defineProps<ProposalListProps>();
 const { proposals } = toRefs(props);
-const selectedVotes = useLocalSelectedVotes();
 
 const hasProposals = computed(
   () => proposals.value && proposals.value.length > 0,

--- a/pages/proposals/index.vue
+++ b/pages/proposals/index.vue
@@ -135,7 +135,7 @@ const hasProposals = computed(
 );
 
 const isSelectedCastProposalsFull = computed(() => {
-  return selectedVotes.length === mandatoryToVoteProposals.value.length;
+  return selectedVotes.length >= mandatoryToVoteProposals.value.length;
 });
 
 const progressBarWidth = computed(() => {

--- a/pages/proposals/index.vue
+++ b/pages/proposals/index.vue
@@ -166,7 +166,7 @@ useHead({
 });
 
 function onCast(vote: number, proposalId: string) {
-  selectedVotes.add({ proposalId, vote });
+  selectedVotes.cast({ proposalId, vote });
 }
 
 function updateReasonForVote(value: string, proposalId: string) {

--- a/pages/proposals/index.vue
+++ b/pages/proposals/index.vue
@@ -134,6 +134,7 @@ const hasProposals = computed(
   () => mandatoryToVoteProposals && mandatoryToVoteProposals.value.length > 0,
 );
 
+// TODO: fix me
 const isSelectedCastProposalsFull = computed(() => {
   return selectedVotes.length >= mandatoryToVoteProposals.value.length;
 });

--- a/pages/proposals/index.vue
+++ b/pages/proposals/index.vue
@@ -134,9 +134,10 @@ const hasProposals = computed(
   () => mandatoryToVoteProposals && mandatoryToVoteProposals.value.length > 0,
 );
 
-// TODO: fix me
 const isSelectedCastProposalsFull = computed(() => {
-  return selectedVotes.length >= mandatoryToVoteProposals.value.length;
+  return mandatoryToVoteProposals.value.every((item) => {
+    selectedVotes.has(item.proposalId);
+  });
 });
 
 const progressBarWidth = computed(() => {

--- a/pages/proposals/zero.vue
+++ b/pages/proposals/zero.vue
@@ -24,8 +24,7 @@
     <ProposalList
       :proposals="proposals"
       :loading="isLoading"
-      :selected-proposal="selectedProposal"
-      @on-cast="confirmCastVote"
+      @on-cast="castVote"
     >
       <template #emptyState>
         <ProposalListEmptyState> No Zero proposals </ProposalListEmptyState>
@@ -59,10 +58,6 @@ const votingPower = ref();
 const proposals = computed(() =>
   proposalsStore.getProposalsTypeZero.filter((p) => p.state === "Active"),
 );
-
-async function confirmCastVote(vote: number, proposalId: string) {
-  castVote(vote, proposalId);
-}
 
 async function castVote(vote: number, proposalId: string) {
   await forceSwitchChain();

--- a/stores/localSelectedVotes.ts
+++ b/stores/localSelectedVotes.ts
@@ -24,6 +24,25 @@ export const useLocalSelectedVotes = defineStore("selectedVotes", {
 
   getters: {
     length: (state) => state.selected.length,
+
+    /**
+     * Returns the vote of the selected proposal
+     *
+     * @param proposalId - The proposal id
+     * @returns The vote of the selected proposal
+     * @returns `null` if the proposal is not selected
+     * @returns `true` if the proposal is selected with a vote of `1`
+     * @returns `false` if the proposal is selected with a vote of `0`
+     */
+    get:
+      (state) =>
+      (proposalId: SelectedVote["proposalId"]): boolean | null => {
+        const selected = state.selected.find(
+          (v) => v.proposalId === proposalId,
+        );
+
+        return selected ? (selected.vote === 0 ? false : true) : null;
+      },
   },
 
   actions: {

--- a/stores/localSelectedVotes.ts
+++ b/stores/localSelectedVotes.ts
@@ -1,0 +1,52 @@
+import { defineStore } from "pinia";
+import { useLocalStorage } from "@vueuse/core";
+
+type SelectedVote = {
+  vote: number;
+  proposalId: string;
+  reason?: string;
+};
+
+/**
+ *
+ * Stores the information of the proposals that the user has selected their vote on
+ * but not submitted to the blockchain yet
+ */
+export const useLocalSelectedVotes = defineStore("selectedVotes", {
+  state: () => ({
+    // Data-structure consideration for Array:
+    // The number of selected votes is not expected to be in the thousands nor hundreds.
+    selected: useLocalStorage(
+      "__ttg_selected_votes__",
+      [] as Array<SelectedVote>,
+    ),
+  }),
+
+  getters: {
+    length: (state) => state.selected.length,
+  },
+
+  actions: {
+    add({ vote, proposalId }: SelectedVote) {
+      this.selected.push({ vote, proposalId });
+    },
+
+    remove(proposalId: SelectedVote["proposalId"]) {
+      this.selected = this.selected.filter((v) => v.proposalId !== proposalId);
+    },
+
+    update(newSelect: Partial<SelectedVote>) {
+      this.selected = this.selected.map((select) => {
+        if (select.proposalId === newSelect.proposalId) {
+          return { ...select, ...newSelect };
+        }
+
+        return select;
+      });
+    },
+
+    clean() {
+      this.selected = [];
+    },
+  },
+});

--- a/stores/localSelectedVotes.ts
+++ b/stores/localSelectedVotes.ts
@@ -32,21 +32,28 @@ export const useLocalSelectedVotes = defineStore("selectedVotes", {
   },
 
   actions: {
-    add({ vote, proposalId }: SelectedVote) {
-      this.selected.push({ vote, proposalId });
+    cast({ vote, proposalId }: SelectedVote) {
+      if (this.get(proposalId)) {
+        this.update({
+          vote,
+          proposalId,
+        });
+      } else {
+        this.selected.push({ vote, proposalId });
+      }
     },
 
     remove(proposalId: SelectedVote["proposalId"]) {
       this.selected = this.selected.filter((v) => v.proposalId !== proposalId);
     },
 
-    update(newSelect: Partial<SelectedVote>) {
-      this.selected = this.selected.map((select) => {
-        if (select.proposalId === newSelect.proposalId) {
-          return { ...select, ...newSelect };
+    update(newCast: Partial<SelectedVote>) {
+      this.selected = this.selected.map((cast) => {
+        if (cast.proposalId === newCast.proposalId) {
+          return { ...cast, ...newCast };
         }
 
-        return select;
+        return cast;
       });
     },
 

--- a/stores/localSelectedVotes.ts
+++ b/stores/localSelectedVotes.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
+import keyBy from "lodash/keyBy";
 
 type SelectedVote = {
   vote: number;
@@ -29,11 +30,17 @@ export const useLocalSelectedVotes = defineStore("selectedVotes", {
       (state) =>
       (proposalId: SelectedVote["proposalId"]): SelectedVote | undefined =>
         state.selected.find((v) => v.proposalId === proposalId),
+
+    byKey: (state) => keyBy(state.selected, "proposalId"),
   },
 
   actions: {
+    has(proposalId: SelectedVote["proposalId"]) {
+      return Object.hasOwn(this.byKey, proposalId);
+    },
+
     cast({ vote, proposalId }: SelectedVote) {
-      if (this.get(proposalId)) {
+      if (this.has(proposalId)) {
         this.update({
           vote,
           proposalId,

--- a/stores/localSelectedVotes.ts
+++ b/stores/localSelectedVotes.ts
@@ -25,24 +25,10 @@ export const useLocalSelectedVotes = defineStore("selectedVotes", {
   getters: {
     length: (state) => state.selected.length,
 
-    /**
-     * Returns the vote of the selected proposal
-     *
-     * @param proposalId - The proposal id
-     * @returns The vote of the selected proposal
-     * @returns `null` if the proposal is not selected
-     * @returns `true` if the proposal is selected with a vote of `1`
-     * @returns `false` if the proposal is selected with a vote of `0`
-     */
     get:
       (state) =>
-      (proposalId: SelectedVote["proposalId"]): boolean | null => {
-        const selected = state.selected.find(
-          (v) => v.proposalId === proposalId,
-        );
-
-        return selected ? (selected.vote === 0 ? false : true) : null;
-      },
+      (proposalId: SelectedVote["proposalId"]): SelectedVote | undefined =>
+        state.selected.find((v) => v.proposalId === proposalId),
   },
 
   actions: {

--- a/stores/proposals.ts
+++ b/stores/proposals.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import orderBy from "lodash/orderBy";
 import uniqBy from "lodash/uniqBy";
+import keyBy from "lodash/keyBy";
 
 import { MProposal, ProposalState } from "@/lib/api/types";
 
@@ -41,6 +42,8 @@ export const useProposalsStore = defineStore("proposals", {
 
   actions: {
     setProposals(proposals: Array<MProposal>) {
+      const localSelectedVotes = useLocalSelectedVotes();
+
       this.data = [];
       this.data = [
         ...orderBy(
@@ -49,7 +52,17 @@ export const useProposalsStore = defineStore("proposals", {
           "desc",
         ),
       ];
+
+      const keyMap = keyBy(this.data, "proposalId");
+
+      // Remove stored votes of past proposals
+      localSelectedVotes.$patch({
+        selected: localSelectedVotes.selected.filter(
+          (cast) => keyMap[cast.proposalId] !== undefined,
+        ),
+      });
     },
+
     push(proposals: Array<MProposal>) {
       this.data = [
         ...orderBy(


### PR DESCRIPTION
Persist the select vote locally in the browser. 

### Main pproach:
1. Use local storage to persist selected votes.
1. Bind it with the UI: changes in voting update the store. UI is a function of the store.
1. Data sync: On proposals' data loaded, filter out any locally stored vote that is no longer relevant.

These changes were applied in both Standard and Priority lists.

### Additional changes
1. Invert reactivity flow control: Instead of UI updating store, now the store updates de UI (no state control in the UI, it just renders whatever the store has)
2. A couple of opportunistic small fixes

### Other implicit changes up to discussion
1. Submitting votes will submit the current list only. e.g., user cast votes on all standard proposal, user goes to priority proposals and select all of them too, user goes back to standard and submit the votes. Result: only standard proposals were voted.

## Demo

https://github.com/user-attachments/assets/b549c549-0265-4b07-a8a5-421d3d6737aa


