### PR TITLE
cleanup(ProposalCard): remove unused on-view event

### DIFF
--- a/components/proposal/Card.vue
+++ b/components/proposal/Card.vue
@@ -191,7 +191,6 @@ const props = defineProps<ProposalCardProps>();
 const emit = defineEmits<{
   (e: "on-cast", vote: number, proposaId: string): void;
   (e: "on-uncast", proposaId: string): void;
-  (e: "on-view", proposaId: string): void;
   (e: "on-execute", proposal: MProposal): void;
   (e: "update-reason-for-vote", value: string, proposalId: string): void;
 }>();

--- a/components/proposal/Card.vue
+++ b/components/proposal/Card.vue
@@ -38,12 +38,11 @@
         {{ truncate(onlyDescription, { length: 450 }) }}
       </div>
 
-      <button
-        id="show-details"
-        type="button"
+      <NuxtLink
+        tag="a"
+        :to="`/proposal/${proposal.proposalId}`"
         class="uppercase text-xs flex justify-between hover:underline border border-gray-200 w-full p-3 my-4"
         data-test="proposal-button-show-details"
-        @click="onViewProposal"
       >
         <span>show details </span>
         <svg
@@ -62,7 +61,7 @@
             fill="currentColor"
           />
         </svg>
-      </button>
+      </NuxtLink>
 
       <div
         v-if="proposal?.state === 'Active'"
@@ -241,10 +240,6 @@ const voteEndTimestamp = ref();
 const { onlyDescription, title } = useParsedDescriptionTitle(
   props.proposal.description,
 );
-
-async function onViewProposal() {
-  await navigateTo(`/proposal/${props.proposal.proposalId}`);
-}
 
 function onExecuteProposal() {
   emit("on-execute", props.proposal);

--- a/components/proposal/List.vue
+++ b/components/proposal/List.vue
@@ -2,17 +2,8 @@
   <div>
     <slot v-if="!hasProposals" name="emptyState"></slot>
     <div v-for="proposal in proposals" v-else :key="proposal.proposalId">
-      <ProposalCard
-        :loading="loading"
-        :proposal="proposal"
-        v-bind="$attrs"
-        @on-view="onViewProposal"
-      />
+      <ProposalCard :loading="loading" :proposal="proposal" v-bind="$attrs" />
     </div>
-
-    <MDrawer ref="modal" @on-closed="onCloseDrawer">
-      <ProposalDetails v-if="showProposal" :proposal-id="currentProposal" />
-    </MDrawer>
   </div>
 </template>
 
@@ -31,24 +22,4 @@ const { proposals } = toRefs(props);
 const hasProposals = computed(
   () => proposals.value && proposals.value.length > 0,
 );
-
-const showProposal = ref<boolean>(false);
-const currentProposal = ref<string>();
-const modal = ref();
-
-async function onViewProposal(proposalId: string) {
-  // do not change this oder;
-  await modal.value.close(); //waits for the drawer to unmount
-  showProposal.value = false; // force unmount content of drawer
-  currentProposal.value = proposalId;
-  showProposal.value = true;
-  modal.value.open();
-  window.history.pushState({}, "", `/proposal/${proposalId}`);
-}
-
-function onCloseDrawer() {
-  showProposal.value = false;
-  currentProposal.value = undefined;
-  window.history.replaceState({}, "", "/proposals/");
-}
 </script>


### PR DESCRIPTION
While working on the proposal page I noticed the `on-view` wasn't really used or needed.

* Remove the `on-view` event 
* Use a native anchor component for navigation 


https://github.com/user-attachments/assets/6663187f-e687-4380-84e2-f06ec1927396




I guess it is a leftover from the redesign – @conradocanasm0: please take a look to confirm