### PR TITLE
hotfix(2.1.1): fix power and zero relative voting calculation

### DIFF
--- a/components/header/HeaderProfilePopover.vue
+++ b/components/header/HeaderProfilePopover.vue
@@ -31,7 +31,7 @@
                 <div class="flex items-center gap-2">
                   <component :is="token.icon" class="w-5 h-5" />
                   <span class="text-xl leading-tight">
-                    {{ token.votingPower }}%
+                    {{ token.votingPower.toFixed(4) }}%
                   </span>
                 </div>
                 <span class="text-sm text-grey-500 mb-0.5">
@@ -83,14 +83,14 @@ const tokens = computed(() => {
   return [
     {
       label: "Power",
-      balance: balancePowerToken?.data.value?.formatted || 0n,
-      votingPower: powerVotingPower?.data.value?.relative || 0n,
+      balance: balancePowerToken?.data.value?.formatted || 0,
+      votingPower: powerVotingPower?.data.value?.relative || 0,
       icon: MIconPower,
     },
     {
       label: "Zero",
-      balance: balanceZeroToken?.data.value?.formatted || 0n,
-      votingPower: zeroVotingPower?.data.value?.relative || 0n,
+      balance: balanceZeroToken?.data.value?.formatted || 0,
+      votingPower: zeroVotingPower?.data.value?.relative || 0,
       icon: MIconZero,
     },
   ];

--- a/lib/hooks/useVotingPowerPowerToken.ts
+++ b/lib/hooks/useVotingPowerPowerToken.ts
@@ -26,7 +26,6 @@ export default (
     query: {
       select: (data) => {
         const votingPower = BigInt(data as unknown as bigint);
-        console.log({ votingPower, totalSupply: totalSupply.value });
 
         return {
           relative:

--- a/lib/hooks/useVotingPowerPowerToken.ts
+++ b/lib/hooks/useVotingPowerPowerToken.ts
@@ -14,7 +14,9 @@ export default (
 
   const ttg = storeToRefs(useTtgStore());
   const token = ttg.tokens.value.power;
-  const totalSupply = computed(() => ttg.tokens.value.power.totalSupply.value);
+  const totalSupply = computed<bigint>(
+    () => ttg.tokens.value.power.totalSupply?.value || 0n,
+  );
 
   return useReadContract({
     address: ttg.contracts.value.powerToken as Hash,
@@ -24,12 +26,13 @@ export default (
     query: {
       select: (data) => {
         const votingPower = BigInt(data as unknown as bigint);
+        console.log({ votingPower, totalSupply: totalSupply.value });
 
         return {
           relative:
             votingPower === 0n
               ? 0
-              : Number((votingPower * 100n * 100n) / totalSupply.value) / 100,
+              : (Number(votingPower) / Number(totalSupply.value)) * 100,
           value: votingPower,
           formatted: formatUnits(votingPower, token.decimals || 0),
           hasVotingPower: votingPower > 0n,

--- a/lib/hooks/useVotingPowerZeroToken.ts
+++ b/lib/hooks/useVotingPowerZeroToken.ts
@@ -13,7 +13,9 @@ export default (
   const ttg = storeToRefs(useTtgStore());
 
   const token = ttg.tokens.value.zero;
-  const totalSupply = computed(() => ttg.tokens.value.zero.totalSupply.value);
+  const totalSupply = computed<bigint>(
+    () => ttg.tokens.value.zero.totalSupply?.value || 0n,
+  );
 
   return useReadContract({
     address: ttg.contracts.value.zeroToken as Hash,
@@ -28,7 +30,7 @@ export default (
           relative:
             votingPower === 0n
               ? 0
-              : Number((votingPower * 100n * 100n) / totalSupply.value) / 100,
+              : (Number(votingPower) / Number(totalSupply.value)) * 100,
           value: votingPower,
           formatted: formatUnits(votingPower, token.decimals || 6),
           hasVotingPower: votingPower > 0n,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mzero-ttg-dapp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "engines": {
     "node": ">=18.18"


### PR DESCRIPTION
## Demo
Using an account with 347 voting power and a total supply of 2357946

Before
![Screenshot 2025-03-07 at 14 48 41](https://github.com/user-attachments/assets/5f06a580-44ea-496c-b712-081c4a9db7e1)


After
![Screenshot 2025-03-07 at 14 43 33](https://github.com/user-attachments/assets/13b1c385-ba82-400e-88c7-99e858db2718)